### PR TITLE
Update dependencies to support newer PHP and Illuminate versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
+        "php": "^7.2|^8.0|^8.1|^8.2",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",


### PR DESCRIPTION
Extended compatibility to include PHP 8.1 and 8.2, and added support for Illuminate versions 11 and 12. This ensures better alignment with modern environments and framework updates.